### PR TITLE
Address a build issue

### DIFF
--- a/rust/integration-tests/Cargo.toml
+++ b/rust/integration-tests/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 tokio = { version = "*", features = [ "rt-threaded", "time", "macros" ] }
 serde_json = "*"
 reqwest = "*"
-
-[dev-dependencies]
-serial_test = "*"
+k8s = { path = "../k8s" }

--- a/rust/integration-tests/src/tests.rs
+++ b/rust/integration-tests/src/tests.rs
@@ -1,10 +1,8 @@
 #![cfg(test)]
 use super::test_runner::run_test;
 use serde_json::json;
-use serial_test::serial;
 
 #[test]
-#[serial]
 fn trivial_fixed_response() {
     let results = run_test(
         "trivialfixedresponse",
@@ -21,7 +19,6 @@ fn trivial_fixed_response() {
 }
 
 #[test]
-#[serial]
 fn loops() {
     let results = run_test(
         "loops",

--- a/rust/k8s/Cargo.toml
+++ b/rust/k8s/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kube = "*"
+kube = { version = "0.25.0", features = ["openapi"] }
 k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_17"] }
 serde_json = "*"


### PR DESCRIPTION
The k8s package depends on the kube crate's openapi feature to compile.
However, k8s/Cargo.toml did not specify this requirement. Why did this ever
work? Other packages explicitly depend on kube and specify the openapi feature.
Thus, k8s only builds successfully when it is a depenency of a package that
requires the openapi feature! This is awful.