### PR TITLE
Cleaner, faster shutdown

### DIFF
--- a/containerless/docker/containerless.yaml
+++ b/containerless/docker/containerless.yaml
@@ -137,3 +137,4 @@ spec:
     - name: log
       hostPath:
         path: $CONTROLLER_LOG_PATH
+  terminationGracePeriodSeconds: 1    

--- a/containerless/docker/function-storage/Dockerfile
+++ b/containerless/docker/function-storage/Dockerfile
@@ -2,4 +2,4 @@ FROM ubuntu:latest
 RUN apt-get update
 RUN apt-get install libssl1.1
 COPY function-storage-agent /function-storage-agent
-ENTRYPOINT /function-storage-agent
+CMD ["/function-storage-agent"]

--- a/containerless/rust/Cargo.lock
+++ b/containerless/rust/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "futures-retry",
  "hyper",
  "reqwest",
+ "shared",
  "tokio",
  "warp",
 ]

--- a/containerless/rust/controller-agent/src/controller/common.rs
+++ b/containerless/rust/controller-agent/src/controller/common.rs
@@ -9,16 +9,6 @@ pub use tokio::task;
 pub static NAMESPACE: &'static str = "containerless";
 pub use futures::channel::oneshot;
 
-pub async fn suppress_and_log_err<F, E>(f: F)
-where
-    F: Future<Output = Result<(), E>>,
-    E: std::error::Error,
-{
-    if let Err(err) = f.await {
-        error!(target: "controller", "Error: {:?}", err);
-    }
-}
-
 fn get_root_dir() -> String {
     let mut bin_path = std::env::current_exe().unwrap();
     assert!(bin_path.pop()); // pop controller-agent

--- a/containerless/rust/controller-agent/src/controller/graceful_sigterm.rs
+++ b/containerless/rust/controller-agent/src/controller/graceful_sigterm.rs
@@ -1,10 +1,8 @@
 use super::common::*;
-use super::compiler::Compiler;
 use k8s;
 use kube;
 use lazy_static::lazy_static;
 use regex::Regex;
-use tokio::signal::unix::{signal, SignalKind};
 
 fn is_function(name: &String) -> bool {
     lazy_static! {
@@ -79,13 +77,5 @@ pub async fn delete_dynamic_resources(
         delete_tracing_pods(&k8s_client),
     )
     .await?;
-    return Ok(());
-}
-
-pub async fn handle_sigterm(compiler: Arc<Compiler>) -> Result<(), kube::Error> {
-    let mut sigterm = signal(SignalKind::terminate()).expect("registering SIGTERM handler");
-    sigterm.recv().await;
-    info!("Received SIGTERM");
-    compiler.shutdown().await;
     return Ok(());
 }

--- a/containerless/rust/controller-agent/src/main.rs
+++ b/containerless/rust/controller-agent/src/main.rs
@@ -8,7 +8,6 @@ mod trace_compiler;
 
 use controller::common::*;
 use controller::compiler;
-use controller::graceful_sigterm::handle_sigterm;
 
 #[tokio::main]
 async fn main() {
@@ -32,10 +31,7 @@ async fn main() {
         .expect("failed to create initial dispatcher");
 
     info!(target: "controller", "Controller listening");
-    let (_addr, server) = warp::serve(routes::routes(compiler.clone(), ROOT.as_str()))
-        .bind_with_graceful_shutdown(
-            ([0, 0, 0, 0], 7999),
-            suppress_and_log_err(handle_sigterm(compiler)),
-        );
-    server.await;
+
+    shared::net::serve_until_sigterm(routes::routes(compiler.clone(), ROOT.as_str()), 7999).await;
+    compiler.shutdown().await;
 }

--- a/containerless/rust/function-runner-agent/Cargo.toml
+++ b/containerless/rust/function-runner-agent/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+shared = { path = "../shared" }
 hyper = "*"
 warp = "*"
 tokio = { version = "*", features = ["macros", "process", "fs", "signal"] }

--- a/containerless/rust/function-storage-agent/src/main.rs
+++ b/containerless/rust/function-storage-agent/src/main.rs
@@ -7,6 +7,7 @@ mod routes;
 mod storage;
 
 use storage::Storage;
+use shared;
 
 // Based on:
 // https://github.com/seanmonstar/warp/blob/master/examples/todos.rs
@@ -14,8 +15,6 @@ use storage::Storage;
 #[tokio::main]
 async fn main() {
     let storage = Storage::new_shared_storage();
-    warp::serve(routes::routes(storage))
-        .run(([0, 0, 0, 0], 8080))
-        .await;
+    shared::net::serve_until_sigterm(routes::routes(storage), 8080).await;
     println!("Function Runner Agent terminated");
 }

--- a/containerless/rust/shared/src/net.rs
+++ b/containerless/rust/shared/src/net.rs
@@ -3,6 +3,8 @@ use std::fmt::Display;
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::time;
+use tokio::signal::unix::{signal, SignalKind};
+use warp;
 
 #[derive(Error, Debug)]
 #[error("timeout error: {reason}")]
@@ -53,4 +55,15 @@ where
     U: IntoUrl + Clone + Display,
 {
     return poll_url_internal(client, url, interval, Some(timeout)).await;
+}
+
+pub async fn serve_until_sigterm<F>(filter : F, port: u16) where
+    F : warp::Filter + Clone + Send + Sync + 'static,
+    F::Extract: warp::reply::Reply {
+    let (_addr, server) = warp::serve(filter).bind_with_graceful_shutdown(([0, 0, 0, 0], port), async {
+        let mut sigterm = signal(SignalKind::terminate()).expect("registering SIGTERM handler");
+        sigterm.recv().await;
+        println!("Received SIGTERM");    
+    });
+    server.await;
 }


### PR DESCRIPTION
- Handle SIGTERM in storage
- Set grace period to 1 in controller-logger,
  which sends SIGKILL
- Duplicated boilerplate for SIGTERM handling is now
  consolidated in shared