### PR TITLE
stop using log in integration-tests

### DIFF
--- a/containerless/rust/integration-tests/Cargo.toml
+++ b/containerless/rust/integration-tests/Cargo.toml
@@ -13,4 +13,3 @@ k8s = { path = "../k8s" }
 nix = "*"
 reqwest = "*"
 shared = { path = "../shared" }
-log = "*"

--- a/containerless/rust/integration-tests/src/main.rs
+++ b/containerless/rust/integration-tests/src/main.rs
@@ -1,5 +1,3 @@
-extern crate log;
-
 mod test_runner;
 mod tests;
 mod error;
@@ -13,8 +11,11 @@ use tokio::process::{Child, Command};
 use tokio::signal::unix::{signal, SignalKind};
 
 async fn run_tests() -> Child {
+    // One test thread is needed for these to be reasonable unit tests. Without it, tests may
+    // interfere with each other, since the Dispatcher is very stateful.
+    // The --nocapture option lets us see error messages faster.
     return Command::new("cargo")
-        .args(&["test", "--", "--test-threads=1"])
+        .args(&["test", "--", "--test-threads=1", "--nocapture"])
         .spawn()
         .expect("spawning cargo test");
 }

--- a/containerless/rust/integration-tests/src/test_runner.rs
+++ b/containerless/rust/integration-tests/src/test_runner.rs
@@ -92,14 +92,14 @@ impl TestRunner {
 
 pub async fn run_test_async(name: &str, js_code: &str, js_requests: Vec<(&str, JsonValue)>, rs_requests: Vec<(&str, JsonValue)>) -> Vec<String> {
     fn fail(err: Error) {
-        error!(target: "integration-tests", "Error in the test runner: {:?}", err);
+        eprintln!("fail in the test runner: {:?}", err);
         assert!(false, format!("{:?}", err));
     }
 
     async fn fail_and_delete(runner: TestRunner, name: &str, err: Error) {
-        error!(target: "integration-tests", "Error in the test runner: {:?}", err);
+        eprintln!("Error in the test runner: {:?}", err);
         if let Err(err) = runner.containerless_delete(name).await {
-            error!(target: "integration-tests", "Error in the test runner: {:?}", err);
+            eprintln!("Error deleting function in the test runner: {:?}", err);
         }
         assert!(false, format!("{:?}", err));
     }


### PR DESCRIPTION
- log gives logging macros, but nothing is actually logged without
  a "log provider".
- But, instead of logging, just use println! and eprintln! In
  testing, we don't want to do anything else.
- Use --nocapture to get output faster from tests.