### PR TITLE
Faster test running, removed spurious returns

### DIFF
--- a/containerless/rust/controller-agent/src/controller/compiler.rs
+++ b/containerless/rust/controller-agent/src/controller/compiler.rs
@@ -34,6 +34,7 @@ enum Message {
     },
     CreateFunction {
         name: String,
+        exclusive: bool,
         done: oneshot::Sender<()>,
     },
     ResetFunction {
@@ -217,11 +218,18 @@ async fn compiler_task(compiler: Arc<Compiler>, mut recv_message: mpsc::Receiver
                     .expect("patching dispatcher deployment");
                 info!(target: "controller", "Patched dispatcher deployment");
             }
-            Message::CreateFunction { name, done } => {
+            Message::CreateFunction {
+                name,
+                done,
+                exclusive,
+            } => {
                 if known_functions.contains_key(&name) {
                     known_functions.insert(name.clone(), CompileStatus::Error);
                     error!(target: "controller", "creating function {} twice", name);
                     continue;
+                }
+                if exclusive {
+                    known_functions.clear();
                 }
                 known_functions.insert(name.clone(), CompileStatus::Vanilla);
                 done.send(()).expect("sending done");
@@ -487,10 +495,11 @@ impl Compiler {
         }
     }
 
-    pub async fn create_function(&self, name: &str) -> http::StatusCode {
+    pub async fn create_function(&self, name: &str, exclusive: bool) -> http::StatusCode {
         let (send, recv) = oneshot::channel();
         self.send_message_non_blocking(Message::CreateFunction {
             name: name.to_string(),
+            exclusive,
             done: send,
         });
         recv.await.expect("compiler task shutdown");

--- a/containerless/rust/controller-agent/src/handlers.rs
+++ b/containerless/rust/controller-agent/src/handlers.rs
@@ -55,6 +55,8 @@ pub async fn create_function(
 > {
     info!(target: "controller", "CREATE_FUNCTION {}: entered handler", name);
 
+    let exclusive = contents.exclusive;
+
     // Check that the function name is ok
     let acceptable_chars: Vec<char> = "abcdefghijklmnopqrstuvwxyz1234567890.-".chars().collect();
     if !name.chars().all(|c| acceptable_chars.contains(&c)) {
@@ -82,7 +84,7 @@ pub async fn create_function(
 
     // Add the function to the compiler
     info!(target: "controller", "CREATE_FUNCTION {}: adding to compiler", name);
-    if let Err(err) = add_to_compiler(&name, compiler.clone()).await {
+    if let Err(err) = add_to_compiler(&name, compiler.clone(), exclusive).await {
         error!(target: "controller", "CREATE_FUNCTION {} : Error adding to compiler {:?} ", name, err);
         if let Err(err) = storage::delete(&name).await {
             error!(target: "controller", "CREATE_FUNCTION {} : Error deleting from storage {:?} ", name, err);
@@ -182,8 +184,10 @@ pub async fn list_functions() -> Result<impl warp::Reply, warp::Rejection> {
     }
 }
 
-async fn add_to_compiler(name: &str, compiler: Arc<Compiler>) -> Result<String, Error> {
-    let resp_status = compiler.create_function(&name).await;
+async fn add_to_compiler(
+    name: &str, compiler: Arc<Compiler>, exclusive: bool,
+) -> Result<String, Error> {
+    let resp_status = compiler.create_function(&name, exclusive).await;
     response_into_result(resp_status.as_u16(), format!("Function {} created!", name))
         .map_err(Error::Compiler)
 }

--- a/containerless/rust/integration-tests/src/tests.rs
+++ b/containerless/rust/integration-tests/src/tests.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
 use super::test_runner::run_test;
-
 use serde_json::json;
 
 #[test]

--- a/containerless/rust/shared/src/containerless/controller.rs
+++ b/containerless/rust/shared/src/containerless/controller.rs
@@ -10,6 +10,7 @@ pub async fn create_function(name: &str, filename: &str) -> Result<String, Error
             name
         ))
         .json(&json!({
+            "exclusive": true,
             "contents": format!("{}", fs::read_to_string(filename)?.trim())
         }))
         .send()

--- a/containerless/rust/shared/src/file_contents.rs
+++ b/containerless/rust/shared/src/file_contents.rs
@@ -3,4 +3,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize)]
 pub struct FileContents {
     pub contents: String,
+    /// When set, all other functions get deleted
+    pub exclusive: bool,
 }


### PR DESCRIPTION
When creating a new function, the "exclusive" flag clears all other
functions. So, we don't have to separately delete and create, which
speeds up testing. Right now, the CLI sets exclusive to true, and
there is no way to unset it from the CLI. But, this is an easy
feature to add.

There were also a number of code blocks in the test_runner that
looked like this:

  assert!(false, ...);
  return results;

I've simplified them.