### PR TITLE
Reset trace without recompiling dispatcher.

### DIFF
--- a/containerless/rust/cli/src/main.rs
+++ b/containerless/rust/cli/src/main.rs
@@ -122,7 +122,7 @@ async fn main() {
             println!("{}", output);
         }
         SubCommand::RemoveTrace(t) => {
-            let output = controller::reset_function(&t.name).await.unwrap();
+            let output = controller::reset_trace(&t.name).await.unwrap();
             println!("{}", output);
         }
         SubCommand::Get(t) => {

--- a/containerless/rust/controller-agent/src/controller/compiler.rs
+++ b/containerless/rust/controller-agent/src/controller/compiler.rs
@@ -1,6 +1,5 @@
 //! The compiler uses `cargo build` in the `/src` directory, so it must
 //! run as a single threaded task.
-use super::error::Error;
 use crate::trace_compiler;
 
 use shared::common::*;
@@ -13,7 +12,7 @@ use quote::quote;
 use std::fs;
 use std::io::{self, Write};
 use std::process::Stdio;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use syn::Ident;
 use tokio::process::Command;
 use tokio::task;
@@ -37,10 +36,9 @@ enum Message {
         exclusive: bool,
         done: oneshot::Sender<()>,
     },
-    ResetFunction {
+    ResetTrace {
         name: String,
-        started_compiling: oneshot::Sender<()>,
-        new_dispatcher_deployed: oneshot::Sender<()>,
+        done: oneshot::Sender<()>,
     },
     GetDispatcherVersion {
         done: oneshot::Sender<usize>,
@@ -164,30 +162,6 @@ fn generate_decontainerized_functions_mod(known_functions: &HashMap<String, Comp
     .expect("cannot write function table file");
 }
 
-async fn wait_for_dispatcher_patch_to_complete(
-    k8s: &k8s::Client, desired_version: usize,
-) -> Result<(), Error> {
-    let interval = Duration::from_secs(1);
-    let timeout = Duration::from_secs(60);
-    let end_time = Instant::now() + timeout;
-    let label = format!("app=dispatcher,version={}", desired_version);
-    loop {
-        let dispatcher_pods = k8s
-            .list_pods_by_label_and_field(label.clone(), "status.phase=Running")
-            .await?;
-        if dispatcher_pods.len() == 1 {
-            return Ok(());
-        }
-        tokio::time::delay_for(interval).await;
-        if Instant::now() >= end_time {
-            break;
-        }
-    }
-    return Err(Error::Containerless(
-        "Could not patch dispatcher deployment.".to_string(),
-    ));
-}
-
 async fn compiler_task(compiler: Arc<Compiler>, mut recv_message: mpsc::Receiver<Message>) {
     let k8s = k8s::Client::from_kubeconfig_file(NAMESPACE)
         .await
@@ -245,10 +219,9 @@ async fn compiler_task(compiler: Arc<Compiler>, mut recv_message: mpsc::Receiver
                 known_functions.insert(name.clone(), CompileStatus::Vanilla);
                 done.send(()).expect("sending done");
             }
-            Message::ResetFunction {
+            Message::ResetTrace {
                 name,
-                started_compiling,
-                new_dispatcher_deployed,
+                done
             } => {
                 info!(target: "controller", "clearing compiled function {}", name);
                 let rs_path = format!(
@@ -263,15 +236,11 @@ async fn compiler_task(compiler: Arc<Compiler>, mut recv_message: mpsc::Receiver
                 );
                 match known_functions.remove(&name) {
                     None => {
-                        error!(target: "controller", "clearing compiled function {}: did not find function in known_functions", name);
-                        started_compiling.send(()).expect("sending done");
-                        new_dispatcher_deployed.send(()).expect("sending done")
+                        info!(target: "controller", "clearing compiled function {}: did not find function in known_functions", name);
                     }
                     Some(status) => match status {
                         CompileStatus::Vanilla => {
                             info!(target: "controller", "calling reset on vanilla function: {}", name);
-                            started_compiling.send(()).expect("sending done");
-                            new_dispatcher_deployed.send(()).expect("sending done");
                         }
                         CompileStatus::Compiled => {
                             info!(target: "controller", "clearing compiled function {}: found function in known_functions", name);
@@ -285,27 +254,7 @@ async fn compiler_task(compiler: Arc<Compiler>, mut recv_message: mpsc::Receiver
                                 error!(target: "controller", "error reseting trace for {}: {}", &name, err);
                                 continue;
                             }
-                            generate_decontainerized_functions_mod(&known_functions);
-                            if !(compiler.cargo_build(Some(started_compiling)).await) {
-                                known_functions.insert(name.clone(), CompileStatus::Error);
-                                generate_decontainerized_functions_mod(&known_functions);
-                                error!(target: "controller", "The code for dispatcher-agent is in a broken state. The system may not work.");
-                                continue;
-                            }
-                            next_version += 1;
-                            k8s.patch_deployment(dispatcher_deployment_spec(next_version))
-                                .await
-                                .expect("patching dispatcher deployment");
-                            info!(target: "controller", "Patched dispatcher deployment");
-
-                            if let Err(err) =
-                                wait_for_dispatcher_patch_to_complete(&k8s, next_version).await
-                            {
-                                error!(target: "controller", "Error while waiting for dispatcher to patch: {:?}", err);
-                                continue;
-                            }
-
-                            new_dispatcher_deployed.send(()).expect("sending done");
+                            known_functions.insert(name.clone(), CompileStatus::Vanilla);
                         }
                         CompileStatus::Compiling => {
                             error!(target: "controller", "trace not currently yet built for function {}", name);
@@ -317,6 +266,7 @@ async fn compiler_task(compiler: Arc<Compiler>, mut recv_message: mpsc::Receiver
                         }
                     },
                 }
+                done.send(()).expect("sending done");
             }
             Message::Compile { name, code } => {
                 info!(target: "controller", "compiler task received trace for {}", &name);
@@ -488,19 +438,17 @@ impl Compiler {
         return http::StatusCode::OK;
     }
 
-    pub async fn reset_function(&self, name: &str) -> http::StatusCode {
+    pub async fn reset_trace(&self, name: &str) -> http::StatusCode {
         let (send, recv) = oneshot::channel();
-        let (send2, recv2) = oneshot::channel();
-        self.send_message_non_blocking(Message::ResetFunction {
+        self.send_message_non_blocking(Message::ResetTrace {
             name: name.to_string(),
-            started_compiling: send,
-            new_dispatcher_deployed: send2,
+            done: send,
         });
 
-        match (recv.await, recv2.await) {
-            (Ok(_), Ok(_)) => http::StatusCode::OK,
-            (other1, other2) => {
-                error!(target: "controller", "Recieved error when clearing compiled trace: {:?}\n(ERRCODE {:?})", other1, other2);
+        match recv.await {
+            Ok(_) => http::StatusCode::OK,
+            other1 => {
+                error!(target: "controller", "Recieved error when clearing compiled trace: {:?}", other1);
                 http::StatusCode::INTERNAL_SERVER_ERROR
             }
         }

--- a/containerless/rust/controller-agent/src/controller/error.rs
+++ b/containerless/rust/controller-agent/src/controller/error.rs
@@ -6,7 +6,6 @@ pub enum Error {
     Parsing(String),
     Compiler(String),
     Kube(kube::Error),
-    Containerless(String),
 }
 
 impl Error {
@@ -18,7 +17,6 @@ impl Error {
     pub fn info(&self) -> String {
         match self {
             Error::Compiler(info) => info.to_owned(),
-            Error::Containerless(info) => info.to_owned(),
             Error::Parsing(info) => info.to_owned(),
             error => format!("{:?}", error),
         }

--- a/containerless/rust/controller-agent/src/routes.rs
+++ b/containerless/rust/controller-agent/src/routes.rs
@@ -17,7 +17,7 @@ pub fn routes(
         .or(create_function_route(compiler.clone()))
         .or(delete_function_route(compiler.clone()))
         .or(shutdown_function_instances_route())
-        .or(reset_function_route(compiler.clone()))
+        .or(reset_trace_route(compiler.clone()))
         .or(get_function_route())
         .or(list_functions_route())
         .or(dispatcher_version_route(compiler.clone()))
@@ -110,13 +110,13 @@ fn shutdown_function_instances_route(
         .and_then(handlers::shutdown_function_instances)
 }
 
-fn reset_function_route(
+fn reset_trace_route(
     compiler: Arc<Compiler>,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    warp::path!("reset_function" / String)
+    warp::path!("reset_trace" / String)
         .and(warp::get())
         .and(with_compiler(compiler))
-        .and_then(handlers::reset_function)
+        .and_then(handlers::reset_trace)
 }
 
 fn get_function_route() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone

--- a/containerless/rust/dispatcher-agent-lib/src/dispatcher/function_manager.rs
+++ b/containerless/rust/dispatcher-agent-lib/src/dispatcher/function_manager.rs
@@ -75,6 +75,40 @@ impl FunctionManager {
         }
     }
 
+    pub async fn reset_trace(&mut self) -> Response {
+        let (send, recv) = oneshot::channel();
+        self.send_requests
+            .send(Message::ResetTrace(send))
+            .await
+            .unwrap();
+        match recv.await {
+            Err(err) => {
+                return util::text_response(
+                    500,
+                    format!(
+                        "(function manager shutdown early) dispatcher could not reset trace for {}: {:?}",
+                        self.state.name, err
+                    ),
+                );
+            }
+            Ok(Err(err)) => {
+                return util::text_response(
+                    500,
+                    format!(
+                        "dispatcher could not reset trace for {}: {:?}",
+                        self.state.name, err
+                    ),
+                );
+            }
+            Ok(Ok(())) => {
+                return util::text_response(
+                    200,
+                    format!("Trace reset for {}.", self.state.name),
+                );
+            }
+        }
+    }
+
     pub async fn invoke(
         &mut self, method: http::Method, path_and_query: &str, body: hyper::Body,
     ) -> Result<Response, hyper::Error> {

--- a/containerless/rust/dispatcher-agent-lib/src/dispatcher/function_table.rs
+++ b/containerless/rust/dispatcher-agent-lib/src/dispatcher/function_table.rs
@@ -39,7 +39,7 @@ impl FunctionTable {
         // We use this client to issue requests to serverless functions. So, we expect
         // responses within 15 seconds.
         let mut connector = TimeoutConnector::new(hyper::client::HttpConnector::new());
-        connector.set_connect_timeout(Some(Duration::from_secs(15)));
+        connector.set_connect_timeout(Some(Duration::from_secs(30)));
         let http_client = Arc::new(hyper::Client::builder().build(connector));
 
         // We use this client to send readiness probes in a tight loop.

--- a/containerless/rust/dispatcher-agent-lib/src/dispatcher/serverless_request.rs
+++ b/containerless/rust/dispatcher-agent-lib/src/dispatcher/serverless_request.rs
@@ -3,7 +3,7 @@ use super::types::*;
 #[derive(Copy, Clone)]
 pub enum Mode {
     Tracing(usize),
-    Vanilla,
+    Vanilla(bool), // first invocation
     Decontainerized(Containerless),
 }
 
@@ -12,7 +12,7 @@ impl std::fmt::Display for Mode {
         match self {
             Mode::Decontainerized(_) => f.write_str("Decontainerized"),
             Mode::Tracing(_) => f.write_str("Tracing"),
-            Mode::Vanilla => f.write_str("Vanilla"),
+            Mode::Vanilla(_) => f.write_str("Vanilla"),
         }
     }
 }
@@ -32,5 +32,6 @@ pub enum Message {
     Request(ServerlessRequest),
     ExtractAndCompile(oneshot::Sender<Response>),
     GetMode(oneshot::Sender<Response>),
-    Shutdown(oneshot::Sender<Result<(), crate::error::Error>>)
+    Shutdown(oneshot::Sender<Result<(), crate::error::Error>>),
+    ResetTrace(oneshot::Sender<Result<(), crate::error::Error>>)
 }

--- a/containerless/rust/dispatcher-agent-lib/src/dispatcher/state.rs
+++ b/containerless/rust/dispatcher-agent-lib/src/dispatcher/state.rs
@@ -389,17 +389,6 @@ impl State {
         function_table: Weak<FunctionTable>, create_mode: CreateMode,
         containers_only: bool, containerless: Option<Containerless>, upgrade_pending: Arc<AtomicBool>,
     ) -> Result<(), Error> {
-        try_join!(
-            Self::maybe_start_tracing(
-                self_.clone(),
-                upgrade_pending.load(SeqCst),
-                &create_mode,
-                containers_only,
-                containerless
-            ),
-            Self::maybe_start_vanilla(self_.clone(), &create_mode, containerless)
-        )?;
-
         let init_num_replicas = match create_mode {
             CreateMode::New => 1,
             CreateMode::Adopt {
@@ -417,13 +406,16 @@ impl State {
         );
 
         let mut mode = match (containers_only, containerless) {
-            (true, _) => Mode::Vanilla,
+            (true, _) => Mode::Vanilla(true),
             (false, None) => Mode::Tracing(0),
             (false, Some(f)) => Mode::Decontainerized(f)
         };
 
         while let Some(message) = recv_requests.next().await {
             match (mode, message) {
+                (_, Message::GetMode(send)) => {
+                    util::send_log_error(send, util::text_response(200, format!("{}", mode)));
+                }
                 (_, Message::Shutdown(send_complete)) => {
                     if send_complete.is_canceled() {
                         error!(target: "dispatcher", "trying to send when the reciever is already dropped");
@@ -437,8 +429,27 @@ impl State {
                         return Ok(());
                     }
                 }
-                (_, Message::GetMode(send)) => {
-                    util::send_log_error(send, util::text_response(200, format!("{}", mode)));
+                (Mode::Decontainerized(_func), Message::ResetTrace(send_complete)) => {
+                    if send_complete.is_canceled() {
+                        error!(target: "dispatcher", "trying to send when the reciever is already dropped");
+                        return Err(Error::FunctionManagerTask(
+                            "reciever is already dropped".to_string(),
+                        ));
+                    } else {
+                        // NOTE(emily): when a new dispatcher is deployed and pods are adopted
+                        // the new dispatcher (the one using rust for the function)
+                        // automatically has containers_only set to true. This is OK for
+                        // testing, but should be fixed for deployment
+                        if containers_only {
+                            mode = Mode::Vanilla(true);
+                        } else {
+                            mode = Mode::Tracing(0);
+                        }
+                        send_complete.send(Ok(())).unwrap();
+                    }
+                },
+                (_, Message::ResetTrace(send_complete)) => {
+                    send_complete.send(Ok(())).unwrap();
                 }
                 (Mode::Decontainerized(func), Message::Request(req)) => {
                     let self_ = Arc::clone(&self_);
@@ -465,7 +476,7 @@ impl State {
                                 "extracting and sending trace",
                             ));
                         }
-                        mode = Mode::Vanilla;
+                        mode = Mode::Vanilla(true);
                         debug!(target: "dispatcher", "switched to Vanilla mode for {}", &self_.name);
                     } else {
                         util::send_log_error(
@@ -474,12 +485,43 @@ impl State {
                         );
                     }
                 }
+                (Mode::Tracing(0), Message::Request(req)) => {
+                    try_join!(
+                        Self::maybe_start_tracing(
+                            self_.clone(),
+                            upgrade_pending.load(SeqCst),
+                            &create_mode,
+                            containers_only,
+                            containerless
+                        ),
+                        Self::maybe_start_vanilla(self_.clone(), &create_mode, containerless)
+                    )?;
+
+                    debug!(target: "dispatcher", "INVOKE {}: FMT in Tracing mode recieved request with path {}", self_.name, req.payload.path_and_query);
+                    mode = Mode::Tracing(2);
+                    if self_.tracing_pod_available.load(SeqCst) {
+                        debug!(target: "dispatcher", "INVOKE {}: FMT in Tracing mode invoking(tracing) with request with path {}", self_.name, req.payload.path_and_query);
+                        task::spawn(Self::invoke_tracing(
+                            Arc::clone(&self_),
+                            req,
+                            Arc::clone(&autoscaler),
+                        ));
+                    } else {
+                        debug!(target: "dispatcher", "INVOKE {}: FMT in Tracing mode invoking(vanilla) with request with path {}", self_.name, req.payload.path_and_query);
+                        task::spawn(Self::invoke_vanilla(
+                            Arc::clone(&self_),
+                            req,
+                            Arc::clone(&autoscaler),
+                        ));
+                    }
+                },
                 (Mode::Tracing(5), Message::Request(req)) => {
                     info!(target: "dispatcher", "INVOKE {}: FMT in Tracing mode sending trace to compiler", self_.name);
                     task::spawn(Self::send_trace_then_stop_pod_and_service(Arc::clone(
                         &self_,
                     )));
-                    mode = Mode::Vanilla;
+                    // NOTE(emily): kludge
+                    mode = Mode::Vanilla(false);
                     task::spawn(Self::invoke_vanilla(
                         Arc::clone(&self_),
                         req,
@@ -505,7 +547,17 @@ impl State {
                         ));
                     }
                 }
-                (Mode::Vanilla, Message::Request(req)) => {
+                (Mode::Vanilla(true), Message::Request(req)) => {
+                    Self::maybe_start_vanilla(self_.clone(), &create_mode, containerless).await?;
+                    mode = Mode::Vanilla(false);
+                    debug!(target: "dispatcher", "INVOKE {}: FMT in Vanilla mode recieved request with path {}", self_.name, req.payload.path_and_query);
+                    task::spawn(Self::invoke_vanilla(
+                        Arc::clone(&self_),
+                        req,
+                        Arc::clone(&autoscaler),
+                    ));
+                }
+                (Mode::Vanilla(false), Message::Request(req)) => {
                     debug!(target: "dispatcher", "INVOKE {}: FMT in Vanilla mode recieved request with path {}", self_.name, req.payload.path_and_query);
                     task::spawn(Self::invoke_vanilla(
                         Arc::clone(&self_),

--- a/containerless/rust/dispatcher-agent-lib/src/routes.rs
+++ b/containerless/rust/dispatcher-agent-lib/src/routes.rs
@@ -11,6 +11,7 @@ pub fn routes(
         .or(extract_and_compile_route(state.clone()))
         .or(get_mode_route(state.clone()))
         .or(shutdown_function_instances_route(state.clone()))
+        .or(reset_trace_route(state.clone()))
         .or(dispatcher_route(state.clone()))
         .or(dispatcher_route2(state.clone()))
 }
@@ -46,6 +47,15 @@ fn shutdown_function_instances_route(
         .and(warp::get())
         .and(with_state(state))
         .and_then(handlers::shutdown_function_instances_handler)
+}
+
+fn reset_trace_route(
+    state: Arc<FunctionTable>,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("reset_trace" / String)
+        .and(warp::get())
+        .and(with_state(state))
+        .and_then(handlers::reset_trace_handler)
 }
 
 fn dispatcher_route(

--- a/containerless/rust/dispatcher-agent/src/decontainerized_functions/mod.rs
+++ b/containerless/rust/dispatcher-agent/src/decontainerized_functions/mod.rs
@@ -1,6 +1,1 @@
-use dispatcher_agent_lib::trace_runtime::Containerless;
-use std::collections::HashMap;
-pub fn init() -> HashMap<&'static str, Containerless> {
-    let ht: HashMap<&'static str, Containerless> = HashMap::new();
-    return ht;
-} 
+use dispatcher_agent_lib :: trace_runtime :: Containerless ; use std :: collections :: HashMap ; mod function_hello3 ; pub fn init ( ) -> HashMap < & 'static str , Containerless > { let mut ht : HashMap < & 'static str , Containerless > = HashMap :: new ( ) ; ht . insert ( "hello3" , function_hello3 :: containerless ) ; return ht ; }

--- a/containerless/rust/shared/src/containerless/controller.rs
+++ b/containerless/rust/shared/src/containerless/controller.rs
@@ -40,9 +40,9 @@ pub async fn shutdown_function_instances(name: &str) -> Result<String, Error> {
     .await?)
 }
 
-pub async fn reset_function(name: &str) -> Result<String, Error> {
+pub async fn reset_trace(name: &str) -> Result<String, Error> {
     Ok(reqwest::get(&format!(
-        "http://localhost/controller/reset_function/{}",
+        "http://localhost/controller/reset_trace/{}",
         name
     ))
     .await?

--- a/containerless/rust/shared/src/containerless/dispatcher.rs
+++ b/containerless/rust/shared/src/containerless/dispatcher.rs
@@ -38,3 +38,13 @@ pub async fn shutdown_function_instances(name: &str) -> Result<String, Error> {
     .await?;
     response_into_result(resp.status().as_u16(), resp.text().await?).map_err(Error::Dispatcher)
 }
+
+pub async fn reset_trace(name: &str) -> Result<String, Error> {
+    let resp = reqwest::get(&format!(
+        "http://{}:8080/reset_trace/{}",
+        dispatcher_ip(),
+        name
+    ))
+    .await?;
+    response_into_result(resp.status().as_u16(), resp.text().await?).map_err(Error::Dispatcher)
+}


### PR DESCRIPTION
Accidentally not relevant to deadline. Parking this code here.

Note to future self:

- During benchmarking, deleting the "tracing run" was wacky because I was waiting for the dispatcher to remove (so that it can remove the compiled trace), when in practice the dispatcher may or may not have a compiled trace in it at all (benchmarking for 5 sec versus 60 sec)
- Wrote a bunch of code that deletes a compiled trace without recompiling the dispatcher.
- However, then I realized this is irrelevant for benchmarking, as it is sufficient to just shutdown the function pods, and not delete the compiled trace as well.
- This code currently works well, but there is a bug where after clearing the compiled trace, there are a few "invoke error"'s when switching back to JS.